### PR TITLE
Fix crash due to liquids

### DIFF
--- a/mods/default/nodes.lua
+++ b/mods/default/nodes.lua
@@ -416,6 +416,7 @@ minetest.register_node("default:ice", {
 	description = "Ice",
 	tiles = {"default_ice.png"},
 	drawtype = "liquid",
+	liquidtype = "source",
 	sunlight_propagates = true,
 	is_ground_content = true,
 	paramtype = "light",

--- a/mods/minetest-mod-jumping/jumping/init.lua
+++ b/mods/minetest-mod-jumping/jumping/init.lua
@@ -5,6 +5,7 @@
 			"slime.png",
 		},
 		drawtype = "liquid",
+		liquidtype = "source",
 		sunlight_propagates = true,
 		alpha = 190,
 		groups = {level=0, dig_immediate=3, oddly_breakable_by_hand=1, bouncy=50, fall_damage_add_percent=-100},


### PR DESCRIPTION
    minetest: /build/minetest-QH6cGC/minetest-201505231146/src/nodedef.cpp :823 : virtual void CNodeDefManager::updateTextures(IGameDef*, void (*)(void*, irr::u32, irr::u32), void*):  l'assertion « f->liquid_type == LIQUID_SOURCE » a échoué.
    Abandon (core dumped)
The flag `liquidtype` was missing, causing crashes. I think that other fixes must be made for ice and trampoline, but at least the systematic crash is avoided.